### PR TITLE
[src] Use average stress per vertex to compute tearing candidates

### DIFF
--- a/src/Tearing/TearingAlgorithms.h
+++ b/src/Tearing/TearingAlgorithms.h
@@ -68,6 +68,7 @@ public:
 	int getFractureNumber() const { return m_fractureNumber; }
 
 	const sofa::type::vector< sofa::type::vector<int> >& getTjunctionTriangles() const { return m_TjunctionTriangle; }
+	const sofa::type::vector< sofa::type::vector<int> >& getTjunctionVertices() const { return m_TjunctionVertex; }
 
 	const sofa::type::vector<Coord>& getFracturePath() const { return m_fracturePath; }
 
@@ -150,6 +151,10 @@ private:
 	
 	/// list of triangle where a T junction is blocking the algorithm
 	sofa::type::vector< sofa::type::vector<int> > m_TjunctionTriangle;
+	/// <summary>
+	/// List of vertices at which a T-junction has heppened
+	/// </summary>
+	sofa::type::vector< sofa::type::vector<int> > m_TjunctionVertex;
 
 	/// path created by algoFracturePath
 	sofa::type::vector<Coord> m_fracturePath;

--- a/src/Tearing/TearingAlgorithms.inl
+++ b/src/Tearing/TearingAlgorithms.inl
@@ -61,6 +61,10 @@ void TearingAlgorithms<DataTypes>::algoFracturePath(Coord Pa, Index indexA, Coor
     //computeSegmentMeshIntersection [Pa;Pc]
     bool sideC_resumed = true;
     Index current_triangle = m_triangleGeo->getTriangleInDirection(indexA, Pc - Pa);
+
+    /*debug*/
+    //std::cout << "The new triangle in direction Pc-Pa is : " << current_triangle << std::endl;
+
     bool triangleInDirectionC = true;
     //no triangle around Pa in the direction Pc
     if (current_triangle > m_topology->getNbTriangles() - 1)
@@ -75,12 +79,18 @@ void TearingAlgorithms<DataTypes>::algoFracturePath(Coord Pa, Index indexA, Coor
     vector< double > coordsEdge_listC;
     bool PATH_C_IS_OK = false;
     if (sideC_resumed)
+    {
         PATH_C_IS_OK = computeSegmentMeshIntersection(Pa, indexA, Pc, pointC_inTriangle, triangleC, edges_listC, coordsEdge_listC, input_position);
+
+    }
     m_fracturePath.push_back(Pc);
 
     //computeSegmentMeshIntersection [Pa;Pb]
     bool sideB_resumed = true;
     current_triangle = m_triangleGeo->getTriangleInDirection(indexA, Pb - Pa);
+    /*debug*/
+    //std::cout << "The new triangle in direction Pb-Pa is : " << current_triangle << std::endl;
+
     bool triangleInDirectionB = true;
     //no triangle around Pa in the direction Pb
     if (current_triangle > m_topology->getNbTriangles() - 1)
@@ -130,6 +140,8 @@ void TearingAlgorithms<DataTypes>::algoFracturePath(Coord Pa, Index indexA, Coor
                 VecIds end_points;
                 bool reachBorder = false;
                 bool incision_ok = m_triangleGeo->InciseAlongEdgeList(new_edges, new_points, end_points, reachBorder);
+
+              
                 if (!incision_ok)
                 {
                     dmsg_error("TopologicalChangeManager") << " in InciseAlongEdgeList";
@@ -244,6 +256,10 @@ void TearingAlgorithms<DataTypes>::algoFracturePath(Coord Pa, Index indexA, Coor
             int a = m_fractureNumber;
             int b = indexTriangleMaxStress;
             m_TjunctionTriangle.push_back({ {a},{b} });
+
+            /*Ongoing modification*/
+            int c = indexA;
+            m_TjunctionVertex.push_back({ {a},{c} });
         }
     }
 }

--- a/src/Tearing/TearingEngine.h
+++ b/src/Tearing/TearingEngine.h
@@ -76,6 +76,7 @@ public:
 	Data<Real> d_fractureMaxLength; ///< max length of a fracture
 	
 	Data<bool> d_ignoreTriangles; ///< option to ignore triangle at start
+	Data<bool> d_ignoreVertices; ///< option to ignore vertices instead of the whole triangles
 	Data<VecIDs> d_trianglesToIgnore; ///< list of triangles to ignore at start
 	Data<int> d_stepModulo; ///< to define a number of step between 2 fractures
 	Data<int> d_nbFractureMax; ///< Maximum number of fracture
@@ -92,7 +93,8 @@ public:
 	/// Output Data
 	Data<VecIDs> d_triangleIdsOverThreshold; ///< output vector of triangles candidates from @sa triangleOverThresholdPrincipalStress
 	Data<Real> d_maxStress; ///< output of the maximum stress found
-	
+
+
 	struct TriangleTearingInformation
 	{
 		//Real area;
@@ -133,6 +135,12 @@ protected:
 	/// compute ignored triangle at start of the tearing algo
 	/// </summary>
 	void computeTriangleToSkip();
+
+/// <summary>
+/// add T-junction triangles to the list of ignored triangles
+/// </summary>
+	void processTjunctionTriangle(const vector<vector<int>>& TjunctionTriangle, helper::WriteAccessor<Data<vector<Index>>>& triangleToSkip);
+
 
 private:
 	/// Pointer to the current topology

--- a/src/Tearing/TearingEngine.h
+++ b/src/Tearing/TearingEngine.h
@@ -31,6 +31,7 @@
 
 #include <sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.h>
 #include <sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.h>
+#include <sofa/helper/OptionsGroup.h>
 
 
 namespace sofa::component::engine
@@ -75,6 +76,7 @@ public:
 	Data<Real> d_stressThreshold; ///< threshold value for principal stress
 	Data<Real> d_fractureMaxLength; ///< max length of a fracture
 	
+	Data<sofa::helper::OptionsGroup> d_computeVertexStressMethod; ///< option to choose a method to compute the starting point for fracture
 	Data<bool> d_ignoreTriangles; ///< option to ignore triangle at start
 	Data<bool> d_ignoreVertices; ///< option to ignore vertices instead of the whole triangles
 	Data<VecIDs> d_trianglesToIgnore; ///< list of triangles to ignore at start
@@ -136,10 +138,27 @@ protected:
 	/// </summary>
 	void computeTriangleToSkip();
 
-/// <summary>
-/// add T-junction triangles to the list of ignored triangles
-/// </summary>
+    /// <summary>
+    /// add T-junction triangles to the list of ignored triangles
+    /// </summary>
 	void processTjunctionTriangle(const vector<vector<int>>& TjunctionTriangle, helper::WriteAccessor<Data<vector<Index>>>& triangleToSkip);
+	/// <summary>
+	/// select the vertex with the maximum (area) weighted average of principal stress values
+	/// </summary>
+	Index computeVertexByArea_WeightedAverage();
+	/// <summary>
+	/// select the vertex with the maximum unweighted average of principal stress values
+	/// </summary>
+	Index computeVertexByUnweightedAverage();
+	/// <summary>
+	/// select the vertex with the maximum (distance) weighted average of principal stress values
+	/// </summary>
+	Index computeVertexByInverseDistance_WeightedAverage();
+	/// <summary>
+	/// for a given vertex, compute the reciprocal of its distance with centroids of triangles
+	/// around it
+	/// </summary>
+	void calculate_inverse_distance_weights(std::vector<double>& result, const Index vertex, sofa::type::vector<Index>& ValidTrianglesAround);
 
 
 private:

--- a/src/Tearing/TearingEngine.inl
+++ b/src/Tearing/TearingEngine.inl
@@ -121,10 +121,9 @@ void TearingEngine<DataTypes>::init()
     if (m_triangularFEM)
     {
         msg_info() << "Using TriangularFEMForceField component";
-        /*Ronak-Debug*/
-        std::cout << "m_triangularFEM is not null!" << std::endl;
+       
         helper::ReadAccessor< Data<VecTriangleFEMInformation> > triangleFEMInf(m_triangularFEM->triangleInfo);
-        std::cout << "m_triangularFEM size is " << triangleFEMInf.size() << std::endl;
+        
     }
     else
     {
@@ -153,8 +152,6 @@ void TearingEngine<DataTypes>::init()
 
     sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 
-    /*Ronak-debug*/
-    std::cout << "--------------------------------End of init function--------------------------------" << std::endl;
 }
 
 template <class DataTypes>
@@ -171,8 +168,7 @@ void TearingEngine<DataTypes>::doUpdate()
 
     m_stepCounter++;
     
-    /*Ronak-modification*/
- 
+   
     if (d_ignoreTriangles.getValue())
     {
         if (m_tearingAlgo != nullptr) 
@@ -189,9 +185,9 @@ void TearingEngine<DataTypes>::doUpdate()
             if (TjunctionTriangle.size())
                 processTjunctionTriangle(TjunctionTriangle, triangleToSkip);
 
-            for (unsigned int j = 0; j < triangleToSkip.size(); j++)
-                std::cout << triangleToSkip[j] << " ";
-            std::cout << std::endl;
+          //  for (unsigned int j = 0; j < triangleToSkip.size(); j++)
+               // std::cout << triangleToSkip[j] << " ";
+           // std::cout << std::endl;
 
 
         }
@@ -208,11 +204,9 @@ void TearingEngine<DataTypes>::doUpdate()
     //        if (TjunctionTriangle[i][0] == m_tearingAlgo->getFractureNumber())
     //        {
     //            if (std::find(triangleToSkip.begin(), triangleToSkip.end(), TjunctionTriangle[i][1]) == triangleToSkip.end())
-    //            {
     //                triangleToSkip.push_back(TjunctionTriangle[i][1]);
-    //                /*Ronak-debug*/
-    //                std::cout << "The index of T_juncion triangle is :" << TjunctionTriangle[i][1] << std::endl;
-    //            }
+    //               
+    //            
     //        }
     //    }
     //}
@@ -223,7 +217,7 @@ void TearingEngine<DataTypes>::doUpdate()
         d_trianglesToIgnore.setValue(emptyIndexList);
     }
 
-    /*Ronak-modification*/
+    /*Ongoing modification*/
 
    /* if (d_ignoreVertices)
     {
@@ -238,8 +232,7 @@ void TearingEngine<DataTypes>::doUpdate()
 
     updateTriangleInformation();
     triangleOverThresholdPrincipalStress();
-    /*Ronak-debug*/
-    std::cout << "-----------------------------End of doUpdate function-----------------------------" << std::endl;
+    
 }
 
 
@@ -274,9 +267,7 @@ void TearingEngine<DataTypes>::triangleOverThresholdPrincipalStress()
             if (tinfo.maxStress >= threshold)
             {
                 candidate.push_back(i);
-                /*Ronak-debug*/
-                //std::cout << "The value of \sigma_1 is " << tinfo.maxStress
-                    //<< " and the index of this candidate is " << i << std::endl;
+                
             }
 
             if (tinfo.maxStress > maxStress)
@@ -286,8 +277,7 @@ void TearingEngine<DataTypes>::triangleOverThresholdPrincipalStress()
             }
         }
     }
-    /*Ronak-debug*/
-    //std::cout << "The value of  m_maxStressTriangleIndex in triangleOverThresholdPrincipalStress function: " << m_maxStressTriangleIndex << std::endl;
+   
 
     //if (candidate.size())
     //{
@@ -296,14 +286,12 @@ void TearingEngine<DataTypes>::triangleOverThresholdPrincipalStress()
     //    k = (tinfo.stress[k] > tinfo.stress[2]) ? k : 2;
     //    m_maxStressVertexIndex = triangleList[m_maxStressTriangleIndex][k];
     //    //d_stepModulo.setValue(0);
-    //    /*Ronak-debug*/
-    //    std::cout << "The stress value for the triangle with maximum principle stress: " <<
-    //        tinfo.stress[0] << " " << tinfo.stress[1] << " " << tinfo.stress[2] << std::endl;
+    //   
     //}
    
-    /*Ronak-modification*/
+    
     //Computing the vertex with maximum stress using the 
-    //principle stress of the triangles adjacent to that vertex
+    //principle stress of the triangles adjacent to that vertices
 
     if (candidate.size())
         {
@@ -349,7 +337,7 @@ void TearingEngine<DataTypes>::triangleOverThresholdPrincipalStress()
              k = (StressPerVertex[k] > StressPerVertex[2]) ? k : 2;
          
              m_maxStressVertexIndex = triangles[m_maxStressTriangleIndex][k];
-             std::cout << "m_maxStressPerVertex is : " << m_maxStressVertexIndex << std::endl;
+             //std::cout << "m_maxStressPerVertex is : " << m_maxStressVertexIndex << std::endl;
            
         }
 
@@ -575,9 +563,6 @@ void TearingEngine<DataTypes>::handleEvent(sofa::core::objectmodel::Event* event
 template <class DataTypes>
 void TearingEngine<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {    
-    /*Ronak-Debug*/
-    //std::cout << "The value of  m_maxStressTriangleIndex in draw function: " << m_maxStressTriangleIndex << std::endl;
-
     if (d_showTearableCandidates.getValue())
     {
         VecTriangles triangleList = m_topology->getTriangles();
@@ -636,14 +621,10 @@ void TearingEngine<DataTypes>::draw(const core::visual::VisualParams* vparams)
         const VecIDs& triIds = d_trianglesToIgnore.getValue();
         std::vector<Vec3> verticesIgnore;
         sofa::type::RGBAColor colorIgnore(1.0f, 0.0f, 0.0f, 1.0f);
-        /*Ronak-debug*/
-        //std::cout << "The list of indices to be ignored :" << std::endl;
+        
 
         for (auto triId : triIds)
         {
-            /*Ronak-debug*/
-            //std::cout << triId << " ";
-
             Coord Pa = x[triangleList[triId][0]];
             Coord Pb = x[triangleList[triId][1]];
             Coord Pc = x[triangleList[triId][2]];


### PR DESCRIPTION
To choose a vertex to start the fracture in the potential triangle:
- for each vertex of the triangle, it computes the average principle stress of the valid triangles adjacent to the vertex
- the vertex with the maximum average value is selected as the fracture starting point.