### PR TITLE
[TearingEngine] Fix handleEvent logic if other event happened and clean draw method

### DIFF
--- a/src/Tearing/TearingEngine.inl
+++ b/src/Tearing/TearingEngine.inl
@@ -915,8 +915,7 @@ void TearingEngine<DataTypes>::handleEvent(sofa::core::objectmodel::Event* event
     }
     else if (((m_stepCounter % step) == 0) && (m_tearingAlgo->getFractureNumber() < d_nbFractureMax.getValue()))
     {
-        if (m_stepCounter > d_stepModulo.getValue())
-            algoFracturePath();
+        algoFracturePath();
     }
 }
 


### PR DESCRIPTION
- Only perform action in handleEvent if we are at the end of a step. Otherwise computation could happened at a higher pace if other events are received like keypress event or mouse click, etc.
- Clean draw method to display triangles candidates in blue, selected in green and ignored in red.