### PR TITLE
[src] Clean duplicated code due to inheritence

### DIFF
--- a/src/Tearing/BaseTearingEngine.h
+++ b/src/Tearing/BaseTearingEngine.h
@@ -118,7 +118,9 @@ protected:
 	/// <summary>
 	/// compute fracture path intersection point and cut through them
 	/// </summary>
-	virtual void algoFracturePath()=0;
+	virtual void algoFracturePath() = 0;
+
+	virtual void computeFracturePath() = 0;
 	
 	void computeFractureDirection(Coord principleStressDirection, Coord& fracture_direction);
 

--- a/src/Tearing/BaseTearingEngine.h
+++ b/src/Tearing/BaseTearingEngine.h
@@ -194,6 +194,10 @@ protected:
 	vector<TriangleTearingInformation> m_triangleInfoTearing; ///< vector of TriangleInfo from FEM
 	int m_stepCounter = 0; ///< counter of doUpdate called by the simulation. Used to put gap between consecutives fractures
 
+	/// Fracture segment endpoints
+	std::vector<Coord> fractureSegmentEndpoints;
+
+
 };
 		
 }//namespace sofa::component::engine

--- a/src/Tearing/BaseTearingEngine.inl
+++ b/src/Tearing/BaseTearingEngine.inl
@@ -50,8 +50,8 @@ BaseTearingEngine<DataTypes>::BaseTearingEngine()
     , d_stepModulo(initData(&d_stepModulo, 20, "step", "step size"))
     , d_nbFractureMax(initData(&d_nbFractureMax, 15, "nbFractureMax", "number of fracture max done by the algorithm"))
 
-    , d_showTearableCandidates(initData(&d_showTearableCandidates, true, "showTearableTriangle", "Flag activating rendering of fracturable triangle"))
-    , d_showFracturePath(initData(&d_showFracturePath, true, "showFracturePath", "Flag activating rendering of fracture path"))
+    , d_showTearableCandidates(initData(&d_showTearableCandidates, false, "showTearableTriangle", "Flag activating rendering of fracturable triangle"))
+    , d_showFracturePath(initData(&d_showFracturePath, false, "showFracturePath", "Flag activating rendering of fracture path"))
     
     , d_triangleIdsOverThreshold(initData(&d_triangleIdsOverThreshold, "triangleIdsOverThreshold", "triangles with maxStress over threshold value"))
     , d_maxStress(initData(&d_maxStress, Real(0.0), "maxStress", "maxStress"))
@@ -639,24 +639,7 @@ void BaseTearingEngine<DataTypes>::handleEvent(sofa::core::objectmodel::Event* e
         return; // We only launch computation at end of a simulation step
     }
 
-
-    //// Compute the current fracture path
-    //if (!d_fractureMaxLength.getValue() && m_maxStressTriangleIndex != InvalidID)
-    //{
-    //    //Recording the endpoints of the fracture segment
-    //    helper::ReadAccessor< Data<VecCoord> > x(d_input_positions);
-    //    Coord principalStressDirection = m_triangleInfoTearing[m_maxStressTriangleIndex].principalStressDirection;
-    //    Coord Pa = x[m_maxStressVertexIndex];
-
-    //    Coord Pb, Pc;
-    //    fractureSegmentEndpoints.clear();
-    //    if (computeEndPointsNeighboringTriangles(Pa, principalStressDirection, Pb, Pc))
-    //    {
-    //        fractureSegmentEndpoints.push_back(Pb);
-    //        fractureSegmentEndpoints.push_back(Pc);
-    //    }
-    //}
-
+    computeFracturePath();
 
     // Hack: we access one output value to force the engine to call doUpdate()
     if (d_maxStress.getValue() == Real(0.0))
@@ -739,6 +722,9 @@ void BaseTearingEngine<DataTypes>::draw(const core::visual::VisualParams* vparam
         }
         vparams->drawTool()->drawTriangles(verticesIgnore, colorIgnore);
     }
+
+
+
 
 
     if (d_showFracturePath.getValue())

--- a/src/Tearing/BaseTearingEngine.inl
+++ b/src/Tearing/BaseTearingEngine.inl
@@ -50,7 +50,7 @@ BaseTearingEngine<DataTypes>::BaseTearingEngine()
     , d_stepModulo(initData(&d_stepModulo, 20, "step", "step size"))
     , d_nbFractureMax(initData(&d_nbFractureMax, 15, "nbFractureMax", "number of fracture max done by the algorithm"))
 
-    , d_showTearableCandidates(initData(&d_showTearableCandidates, false, "showTearableTriangle", "Flag activating rendering of fracturable triangle"))
+    , d_showTearableCandidates(initData(&d_showTearableCandidates, false, "showTearableCandidates", "Flag activating rendering of fracturable triangle"))
     , d_showFracturePath(initData(&d_showFracturePath, false, "showFracturePath", "Flag activating rendering of fracture path"))
     
     , d_triangleIdsOverThreshold(initData(&d_triangleIdsOverThreshold, "triangleIdsOverThreshold", "triangles with maxStress over threshold value"))
@@ -665,8 +665,8 @@ void BaseTearingEngine<DataTypes>::draw(const core::visual::VisualParams* vparam
 {     
     const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
-    if (vparams->displayFlags().getShowWireFrame())
-        vparams->drawTool()->setPolygonMode(0, true);
+    //if (vparams->displayFlags().getShowWireFrame())
+    vparams->drawTool()->setPolygonMode(0, true);
 
     if (d_showTearableCandidates.getValue())
     {
@@ -729,26 +729,27 @@ void BaseTearingEngine<DataTypes>::draw(const core::visual::VisualParams* vparam
 
     if (d_showFracturePath.getValue())
     {
-        if (m_maxStressTriangleIndex != InvalidID)
+        if (m_maxStressTriangleIndex != InvalidID && fractureSegmentEndpoints.size() == 2)
         {
             helper::ReadAccessor< Data<VecCoord> > x(d_input_positions);
             Coord principalStressDirection = m_triangleInfoTearing[m_maxStressTriangleIndex].principalStressDirection;
             Coord Pa = x[m_maxStressVertexIndex];
-            Coord fractureDirection;
-            computeFractureDirection(principalStressDirection, fractureDirection);
-            
+            //Coord fractureDirection;
+            //computeFractureDirection(principalStressDirection, fractureDirection);
+            Coord Pb = fractureSegmentEndpoints[0];
+            Coord Pc = fractureSegmentEndpoints[1];
             
             vector<Coord> points;
-            Real norm_fractureDirection = fractureDirection.norm();
-            Coord Pb = Pa + d_fractureMaxLength.getValue() / norm_fractureDirection * fractureDirection;
-            Coord Pc = Pa - d_fractureMaxLength.getValue() / norm_fractureDirection * fractureDirection;
+            //Real norm_fractureDirection = fractureDirection.norm();
+            //Coord Pb = Pa + d_fractureMaxLength.getValue() / norm_fractureDirection * fractureDirection;
+            //Coord Pc = Pa - d_fractureMaxLength.getValue() / norm_fractureDirection * fractureDirection;
             points.push_back(Pb);
             points.push_back(Pa);
             points.push_back(Pa);
             points.push_back(Pc);
             // Blue == computed fracture path using d_fractureMaxLength
-            vparams->drawTool()->drawPoints(points, 10, sofa::type::RGBAColor(0, 0.2, 1, 1));
-            vparams->drawTool()->drawLines(points, 1, sofa::type::RGBAColor(0, 0.5, 1, 1));
+            vparams->drawTool()->drawPoints(points, 10, sofa::type::RGBAColor(1, 0.2, 1, 1));
+            vparams->drawTool()->drawLines(points, 1, sofa::type::RGBAColor(1, 0.5, 1, 1));
 
             //---------------------------------------------------------------------------------------------------
             // Green == principal stress direction

--- a/src/Tearing/TearingEngine.h
+++ b/src/Tearing/TearingEngine.h
@@ -71,10 +71,9 @@ protected:
 
     using BaseTearingEngine<DataTypes>::d_input_positions;
     using BaseTearingEngine<DataTypes>::d_triangleIdsOverThreshold;
+	using BaseTearingEngine<DataTypes>::fractureSegmentEndpoints;
 	
 public:
-	/// Fracture segment endpoints
-	std::vector<Coord> fractureSegmentEndpoints;
 
 protected:
 

--- a/src/Tearing/TearingEngine.h
+++ b/src/Tearing/TearingEngine.h
@@ -73,9 +73,6 @@ protected:
     using BaseTearingEngine<DataTypes>::d_triangleIdsOverThreshold;
 	
 public:
-	void draw(const core::visual::VisualParams* vparams) override;
-	void handleEvent(sofa::core::objectmodel::Event* event) override;
-	
 	/// Fracture segment endpoints
 	std::vector<Coord> fractureSegmentEndpoints;
 
@@ -100,6 +97,8 @@ protected:
 	bool computeIntersectionNeighborTriangle(Coord normalizedFractureDirection, Coord Pa, Coord& Pb, Real& t);
 	
 	void algoFracturePath() override;
+
+	void computeFracturePath() override;
 	
 	/// <summary>
 	/// computes the the intersection of a segment with one endpoint A with DC segment

--- a/src/Tearing/TearingScenarioEngine.h
+++ b/src/Tearing/TearingScenarioEngine.h
@@ -75,6 +75,8 @@ protected:
 		
 	void computePerpendicular(Coord dir, Coord& normal);
 	void algoFracturePath() override;
+	void computeFracturePath() override {};
+
 	void computeEndPoints(Coord Pa, Coord direction, Coord& Pb, Coord& Pc) override;
 
 	/// Value to store scenario fracture path


### PR DESCRIPTION
- Remove duplicate code in drawing and handleEvent
- Use virtual pure method to compute the path
- Store path at computation to avoid recomputing it in the draw method